### PR TITLE
Update client Dockerfile to copy react app files

### DIFF
--- a/services/client/Dockerfile
+++ b/services/client/Dockerfile
@@ -13,5 +13,8 @@ COPY package-lock.json .
 RUN npm ci
 RUN npm install react-scripts@5.0.1 -g --silent
 
+# add app
+COPY . .
+
 # start app
 CMD ["npm", "start"]


### PR DESCRIPTION
It looks to me like this Dockerfile does not copy any of the React code over, only `package.json` and `package-lock.json`.

When running through this tutorial I experienced the following error when running `docker-compose up`:

```
Could not find a required file.  
Name: index.html 
```

To my understanding this occurs when `react-scripts` attempts to locate the `index.html` file and does not find it in the docker filesystem. After I added the `COPY` command this error went away.

The tutorial [Dockerizing a React App](https://mherman.org/blog/dockerizing-a-react-app/) includes a similar line.